### PR TITLE
Update to latest version of OpenJML, update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-FROM openjdk:8-jdk-stretch
+FROM openjdk:8-jdk-bullseye
 
-RUN apt update && apt install wget unzip
+RUN apt update && apt install -y libgomp1 \
+	&& apt-get -y clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /openjml \
-    && wget https://github.com/OpenJML/OpenJML/releases/download/0.8.43/openjml-0.8.43-20191210.zip --output-document=openjml.zip \
+    && wget https://github.com/OpenJML/OpenJML/releases/download/0.8.59/openjml-0.8.59-20211116.zip --output-document=openjml.zip \
     && unzip openjml.zip -d /openjml \
     && rm openjml.zip 
-
-RUN apt-get purge -y wget unzip \
-    && apt-get -y autoremove \
-    && apt-get autoclean
-
-
 
 #CMD ["java", "-jar", "/openjml/openjml.jar"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker run --rm --name=jml valerioneri/openjml java -jar /openjml/openjml.jar -v
 ### How to run
 To run the OpenJML container you need to mount the directory containing your java files (let's call it *code*) and add the command you want to execute, as in the following example:
 ``` bash
-docker run --rm --name=jml -v $(pwd)/code:/code valerioneri/openjml java -jar /openjml/openjml.jar -esc /code/myFile.java
+docker run --rm --name=jml -v "$(pwd)"/code:/code valerioneri/openjml java -jar /openjml/openjml.jar -esc /code/myFile.java
 ```
 #### OpenJML Execution's options
 
@@ -28,7 +28,7 @@ Based on [OpenJML execution's option documentation ](http://www.openjml.org/docu
 
 ### How to use with docker exec
 ```
-docker run --rm --name=jml -t -d -v $(pwd)/code:/code valerioneri/openjml /bin/bash
+docker run --rm --name=jml -t -d -v "$(pwd)"/code:/code valerioneri/openjml /bin/bash
 docker exec jml  java -jar /openjml/openjml.jar -rac /code/myfile.java
 ```
 


### PR DESCRIPTION
Also rebases on bullseye and fixes z3 not running because of missing libgomp1